### PR TITLE
Add `log` to `BaseYStore` abstract class

### DIFF
--- a/pycrdt_websocket/ystore.py
+++ b/pycrdt_websocket/ystore.py
@@ -35,7 +35,8 @@ class BaseYStore(ABC):
 
     @abstractmethod
     def __init__(
-        self, path: str,
+        self,
+        path: str,
         metadata_callback: Callable[[], Awaitable[bytes] | bytes] | None = None,
         log: Logger | None = None,
     ): ...

--- a/pycrdt_websocket/ystore.py
+++ b/pycrdt_websocket/ystore.py
@@ -35,7 +35,9 @@ class BaseYStore(ABC):
 
     @abstractmethod
     def __init__(
-        self, path: str, metadata_callback: Callable[[], Awaitable[bytes] | bytes] | None = None
+        self, path: str,
+        metadata_callback: Callable[[], Awaitable[bytes] | bytes] | None = None,
+        log: Logger | None = None,
     ): ...
 
     @abstractmethod


### PR DESCRIPTION
Both implementations of `BaseYStore` include `log` in constructor and downstream code expects that it can pass a logger instance to the constructor, so this should be formalised in the abstract class as discussed in https://github.com/jupyterlab/jupyter-collaboration/pull/476#discussion_r2053547599

https://github.com/y-crdt/pycrdt-websocket/blob/4c9f21a9e75d7f726f293674abee820837e44ea7/pycrdt_websocket/ystore.py#L157-L169

https://github.com/y-crdt/pycrdt-websocket/blob/4c9f21a9e75d7f726f293674abee820837e44ea7/pycrdt_websocket/ystore.py#L309-L336