### PR TITLE
Add `ready: bool` annotation to YRoom

### DIFF
--- a/src/pycrdt/websocket/yroom.py
+++ b/src/pycrdt/websocket/yroom.py
@@ -41,6 +41,7 @@ class YRoom:
     ydoc: Doc
     ystore: BaseYStore | None
     ready_event: Event
+    ready: bool
     _on_message: Callable[[bytes], Awaitable[bool] | bool] | None
     _update_send_stream: MemoryObjectSendStream
     _update_receive_stream: MemoryObjectReceiveStream


### PR DESCRIPTION
Adds a ready: bool class‐level annotation to YRoom so mypy recognizes self.ready and the [has-type] error goes away.
CI error: https://github.com/jupyterlab/jupyter-collaboration/actions/runs/14774032452/job/41478969976?pr=480