### PR TITLE
Wait for `start()` to return in `WebsocketServer.stop()`

### DIFF
--- a/src/pycrdt/websocket/websocket_server.py
+++ b/src/pycrdt/websocket/websocket_server.py
@@ -20,6 +20,7 @@ class WebsocketServer:
     rooms: dict[str, YRoom]
     _started: Event | None = None
     _stopped: Event
+    _start_finished: Event
     _task_group: TaskGroup | None = None
     __start_lock: Lock | None = None
 
@@ -62,6 +63,7 @@ class WebsocketServer:
         self.provider_factory = provider_factory
         self.rooms = {}
         self._stopped = Event()
+        self._start_finished = Event()
 
     @property
     def started(self) -> Event:
@@ -69,6 +71,11 @@ class WebsocketServer:
         if self._started is None:
             self._started = Event()
         return self._started
+
+    @property
+    def running(self) -> bool:
+        """Whether the WebSocket server is running."""
+        return self._task_group is not None
 
     @property
     def _start_lock(self) -> Lock:
@@ -219,6 +226,9 @@ class WebsocketServer:
             task_status.started()
             self.started.set()
             assert self._task_group is not None
+            # the context manager awaits the task group on exit, so `stop()` has
+            # nothing to wait for
+            self._start_finished.set()
             # wait until stopped
             self._task_group.start_soon(self._stopped.wait)
             return
@@ -227,26 +237,41 @@ class WebsocketServer:
             if self._task_group is not None:
                 raise RuntimeError("WebsocketServer already running")
 
-            while True:
-                try:
-                    async with create_task_group() as self._task_group:
-                        if not self.started.is_set():
-                            task_status.started()
-                            self.started.set()
-                        # wait until stopped
-                        self._task_group.start_soon(self._stopped.wait)
-                    return
-                except Exception as exception:
-                    self._handle_exception(exception)
+            try:
+                while True:
+                    try:
+                        async with create_task_group() as self._task_group:
+                            if not self.started.is_set():
+                                task_status.started()
+                                self.started.set()
+                            # wait until stopped
+                            self._task_group.start_soon(self._stopped.wait)
+                        return
+                    except Exception as exception:
+                        self._handle_exception(exception)
+            finally:
+                self._start_finished.set()
 
     async def stop(self) -> None:
-        """Stop the WebSocket server."""
+        """Stop the WebSocket server.
+
+        When the server was started through the lower-level API, this waits for the task
+        running `start()` to return, so that the caller can rely on the server's tasks
+        being done when `stop()` returns. Wrap the call in `anyio.move_on_after()` to
+        bound that wait.
+        """
         if self._task_group is None:
             raise RuntimeError("WebsocketServer not running")
 
         self._stopped.set()
         self._task_group.cancel_scope.cancel()
         self._task_group = None
+        if self._start_finished.is_set():
+            # nothing to wait for: don't checkpoint, as we may be running inside the
+            # cancel scope we just cancelled (this is the case when used as an async
+            # context manager, which awaits the task group on exit anyway)
+            return
+        await self._start_finished.wait()
 
 
 def exception_logger(exception: Exception, log: Logger) -> bool:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,9 +1,17 @@
 import pytest
-from anyio import fail_after, sleep
+from anyio import (
+    CancelScope,
+    Event,
+    create_task_group,
+    fail_after,
+    move_on_after,
+    sleep,
+    sleep_forever,
+)
 from utils import create_yws_provider, create_yws_server, get_unused_tcp_port
 
 from pycrdt import Text
-from pycrdt.websocket import exception_logger
+from pycrdt.websocket import WebsocketServer, exception_logger
 
 pytestmark = pytest.mark.anyio
 
@@ -58,3 +66,56 @@ async def test_server_provider():
                     break
 
     assert str(text2) == "Hello"
+
+
+async def test_stop_waits_for_start_to_return():
+    # A task that is slow to unwind, so that the moment `stop()` returns is
+    # observably distinct from the moment `start()` returns.
+    async def slow_to_cancel():
+        try:
+            await sleep_forever()
+        finally:
+            with CancelScope(shield=True):
+                await sleep(0.1)
+
+    server = WebsocketServer()
+    start_returned = Event()
+
+    async def run_server():
+        await server.start()
+        start_returned.set()
+
+    async with create_task_group() as tg:
+        tg.start_soon(run_server)
+        await server.started.wait()
+        server._task_group.start_soon(slow_to_cancel)
+        await sleep(0.1)
+        await server.stop()
+        assert start_returned.is_set()
+
+
+async def test_stop_can_be_bounded_by_the_caller():
+    # A task that cannot be cancelled, so that `stop()` has something to wait for.
+    # The caller must be able to give up on it rather than block forever.
+    async def never_cancels():
+        with CancelScope(shield=True):
+            await sleep(0.5)
+
+    server = WebsocketServer()
+
+    async with create_task_group() as tg:
+        tg.start_soon(server.start)
+        await server.started.wait()
+        server._task_group.start_soon(never_cancels)
+        await sleep(0.1)
+        with fail_after(0.3):
+            with move_on_after(0.1):
+                await server.stop()
+
+
+async def test_context_manager_stop_does_not_stall():
+    # The context manager awaits the task group itself on exit, so `stop()` has
+    # nothing to wait for and must not block on its way out.
+    with fail_after(1):
+        async with WebsocketServer():
+            pass


### PR DESCRIPTION
## The problem

`stop()` cancels the task group and returns immediately:

```python
async def stop(self) -> None:
    if self._task_group is None:
        raise RuntimeError("WebsocketServer not running")
    self._stopped.set()
    self._task_group.cancel_scope.cancel()
    self._task_group = None
```

Cancelling a scope only requests cancellation. The task running `start()` still has to unwind its task group, and `stop()` does not wait for that. So after `await server.stop()` returns, the server's tasks may still be running, and the task running `start()` may never be observed to complete.

That matters more than it looks, because of how anyio cleans up its thread pool. `anyio.to_thread.run_sync()` spawns `WorkerThread`s which are not daemon threads, and the only thing that ever stops them is a callback attached to the root task:

```python
# anyio/_backends/_asyncio.py
class WorkerThread(Thread):
    def __init__(...):
        super().__init__(name="AnyIO worker thread")   # note: not daemon
...
    root_task.add_done_callback(worker.stop, ...)
```

When the root task never completes, those threads are never stopped, and `threading._shutdown()` joins them forever at interpreter exit.

The lower-level API documented in `WebsocketServer.__init__` is what hits this:

```py
task = asyncio.create_task(websocket_server.start())
await websocket_server.started.wait()
...
await websocket_server.stop()
```

A fire-and-forget `start()` task that nobody awaits is exactly what anyio's `find_root_task()` will settle on under a `run_forever()` loop (which is what tornado's `IOLoop.start()` does).

## Observation

Downstream, `jupyter-server-ydoc` drives this API and pairs it with a thread-backed store (`SQLiteYStore`, via `sqlite-anyio`), so it spawns anyio worker threads and then hangs on shutdown. Reproduced on a real server, a `py-spy dump` of the wedged process:

```
Thread 51 (active): "MainThread"
    _shutdown (threading.py:1590)
        Locals:
            locks: [<_thread.lock ...>, <_thread.lock ...>]

Thread 149 (idle): "AnyIO worker thread"
    wait (threading.py:327)
    get (queue.py:171)
    run (anyio/_backends/_asyncio.py:1018)
    _bootstrap_inner (threading.py:1045)

Thread 150 (idle): "AnyIO worker thread"
    ... identical ...
```

The main thread is in `threading._shutdown()` holding exactly two locks, and the two threads it is joining are anyio worker threads parked in `WorkerThread.run`. The process never exits.

Measured on that server - JupyterLab driven by a browser (open two notebooks, edit a cell in each, close the tabs, let the kernels idle-cull, let the no-activity shutdown fire):

| build | cycles | result |
| --- | --- | --- |
| unpatched | 3 | hung 3/3 — log stops after the last extension stops, process never exits |
| **this patch alone**, nothing else changed | 7 | **clean exit 7/7** |
| this patch + a downstream tidy-up | 5 | clean exit 5/5 |

The middle row is the one that matters here: this change on its own is sufficient, with the downstream package left exactly as shipped, across two independently built images. 

### Related issues
[jupyterlab/jupyter-collaboration#161](https://github.com/jupyterlab/jupyter-collaboration/issues/161)
[jupyterlab/jupyter-collaboration#514](https://github.com/jupyterlab/jupyter-collaboration/pull/514)
[jupyterlab/jupyter-collaboration#546](https://github.com/jupyterlab/jupyter-collaboration/pull/546)

## The change

`start()` sets an event when it returns; `stop()` waits on it.

The wait is **cancellable**, so callers bound it themselves:

```python
with move_on_after(2):
    await server.stop()
```

Also adds a `running` property, so callers can check whether `stop()` is valid to call without reaching for `_task_group`.


## Note on restart

While writing the tests I found that `WebsocketServer` cannot currently be restarted at all: `_stopped` is never reset, so a second `start()` returns immediately and leaves a stale task group behind. I have left that alone here to keep this change focused.
